### PR TITLE
Ability to accept connections on multiple endpoints

### DIFF
--- a/include/pion/http/plugin_server.hpp
+++ b/include/pion/http/plugin_server.hpp
@@ -11,6 +11,7 @@
 #define __PION_PLUGIN_SERVER_HEADER__
 
 #include <string>
+#include <utility> // std::move
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
@@ -82,6 +83,31 @@ public:
     { 
         set_logger(PION_GET_LOGGER("pion.http.plugin_server"));
     }
+
+#ifdef BOOST_ASIO_HAS_MOVE
+    /**
+     * creates a new plugin_server object
+     *
+     * @param endpoints TCP endpoints used to listen for new connections (see ASIO docs)
+     */
+    explicit plugin_server(endpoints_t endpoints) :
+        http::server{ move(endpoints) }
+    {
+        set_logger(PION_GET_LOGGER("pion.http.plugin_server"));
+    }
+
+    /**
+     * creates a new plugin_server object
+     *
+     * @param sched the scheduler that will be used to manage worker threads
+     * @param endpoints TCP endpoints used to listen for new connections (see ASIO docs)
+     */
+    plugin_server(scheduler& sched, endpoints_t endpoints) :
+        http::server{ sched, move(endpoints) }
+    {
+        set_logger(PION_GET_LOGGER("pion.http.plugin_server"));
+    }
+#endif
 
     /**
      * adds a new web service to the web server

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <string>
+#include <utility> // std::move
 #include <boost/asio.hpp>
 #include <boost/function.hpp>
 #include <boost/function/function2.hpp>
@@ -111,6 +112,39 @@ public:
     { 
         set_logger(PION_GET_LOGGER("pion.http.server"));
     }
+
+#ifdef BOOST_ASIO_HAS_MOVE
+    /**
+     * creates a new server object
+     *
+     * @param endpoints TCP endpoints used to listen for new connections (see ASIO docs)
+     */
+    explicit server(endpoints_t endpoints) :
+        tcp::server{ move(endpoints) },
+        m_bad_request_handler{ server::handle_bad_request },
+        m_not_found_handler{ server::handle_not_found_request },
+        m_server_error_handler{ server::handle_server_error },
+        m_max_content_length{ http::parser::DEFAULT_CONTENT_MAX }
+    {
+        set_logger(PION_GET_LOGGER("pion.http.server"));
+    }
+
+    /**
+     * creates a new server object
+     *
+     * @param sched the scheduler that will be used to manage worker threads
+     * @param endpoints TCP endpoints used to listen for new connections (see ASIO docs)
+     */
+    server(scheduler& sched, endpoints_t endpoints) :
+        tcp::server{ sched, move(endpoints) },
+        m_bad_request_handler{ server::handle_bad_request },
+        m_not_found_handler{ server::handle_not_found_request },
+        m_server_error_handler{ server::handle_server_error },
+        m_max_content_length{ http::parser::DEFAULT_CONTENT_MAX }
+    {
+        set_logger(PION_GET_LOGGER("pion.http.server"));
+    }
+#endif
 
     /**
      * adds a new web service to the HTTP server

--- a/include/pion/tcp/connection.hpp
+++ b/include/pion/tcp/connection.hpp
@@ -94,10 +94,12 @@ public:
     static inline boost::shared_ptr<connection> create(boost::asio::io_context& io_context,
                                                           ssl_context_type& ssl_context,
                                                           const bool ssl_flag,
-                                                          connection_handler finished_handler)
+                                                          connection_handler finished_handler,
+                                                          const boost::asio::ip::tcp::endpoint& local_endpoint = boost::asio::ip::tcp::endpoint())
     {
         return boost::shared_ptr<connection>(new connection(io_context, ssl_context,
-                                                                  ssl_flag, finished_handler));
+                                                                  ssl_flag, finished_handler,
+                                                                  local_endpoint));
     }
     
     /**
@@ -656,6 +658,11 @@ public:
     inline unsigned short get_remote_port(void) const {
         return get_remote_endpoint().port();
     }
+
+    /// returns the local endpoint (if it has been provided at construction time)
+    inline const boost::asio::ip::tcp::endpoint& get_local_endpoint(void) const {
+        return m_local_endpoint;
+    }
     
     /// returns reference to the io_context used for async operations
     inline boost::asio::io_context& get_io_context(void) {
@@ -689,7 +696,8 @@ protected:
     connection(boost::asio::io_context& io_context,
                   ssl_context_type& ssl_context,
                   const bool ssl_flag,
-                  connection_handler finished_handler)
+                  connection_handler finished_handler,
+                  const boost::asio::ip::tcp::endpoint& local_endpoint)
         :
 #ifdef PION_HAVE_SSL
         m_ssl_context(boost::asio::ssl::context::sslv23),
@@ -699,7 +707,8 @@ protected:
         m_ssl_socket(io_context), m_ssl_flag(false), 
 #endif
         m_lifecycle(LIFECYCLE_CLOSE),
-        m_finished_handler(finished_handler)
+        m_finished_handler(finished_handler),
+        m_local_endpoint(local_endpoint)
     {
         save_read_pos(NULL, NULL);
     }
@@ -731,6 +740,9 @@ private:
 
     /// function called when a server has finished handling the connection
     connection_handler      m_finished_handler;
+
+    /// optional local endpoint forwarded at construction time
+    const boost::asio::ip::tcp::endpoint m_local_endpoint;
 };
 
 

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -51,9 +51,9 @@ void server::handle_request(const http::request_ptr& http_request_ptr,
 
             if (ec == ERRCOND_CANCELED || ec == ERRCOND_EOF) {
                 // don't spam the log with common (non-)errors that happen during normal operation
-                PION_LOG_DEBUG(m_logger, "Lost connection on port " << get_port() << " (" << ec.message() << ")");
+                PION_LOG_DEBUG(m_logger, "Lost connection on endpoint " << tcp_conn->get_local_endpoint() << " (" << ec.message() << ")");
             } else {
-                PION_LOG_INFO(m_logger, "Lost connection on port " << get_port() << " (" << ec.message() << ")");
+                PION_LOG_INFO(m_logger, "Lost connection on endpoint " << tcp_conn->get_local_endpoint() << " (" << ec.message() << ")");
             }
 
             tcp_conn->finish();

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -7,6 +7,7 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
+#include <utility>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/thread/mutex.hpp>
@@ -17,86 +18,180 @@
 namespace pion {    // begin namespace pion
 namespace tcp {     // begin namespace tcp
 
+#ifdef BOOST_ASIO_HAS_MOVE
+acceptors_base::acceptors_base(scheduler& sched, size_t n) :
+    m_active_scheduler{ sched }
+{
+    m_tcp_acceptors.reserve(n);
+    for (size_t i = 0; i < n; ++i)
+        m_tcp_acceptors.emplace_back(m_active_scheduler.get_executor());
+}
+
+acceptors_base::acceptors_base(size_t n) :
+    m_default_scheduler{},
+    m_active_scheduler{ m_default_scheduler }
+{
+    m_tcp_acceptors.reserve(n);
+    for (size_t i = 0; i < n; ++i)
+        m_tcp_acceptors.emplace_back(m_active_scheduler.get_executor());
+}
+
+acceptors_base::~acceptors_base()
+{}
+
+void acceptors_base::resize_acceptors(size_t n)
+{
+    // decrase number of acceptors_base
+    if (n < m_tcp_acceptors.size()) {
+        m_tcp_acceptors.erase(m_tcp_acceptors.cbegin() + n, m_tcp_acceptors.cend());
+    }
+    // incrase number of acceptors_base
+    else if (n > m_tcp_acceptors.size()) {
+        m_tcp_acceptors.reserve(n);
+        for (size_t i = m_tcp_acceptors.size(); i < n; ++i)
+            m_tcp_acceptors.emplace_back(m_active_scheduler.get_executor());
+    }
+}
+#else
+acceptors_base::acceptors_base(scheduler& sched, size_t) :
+    m_active_scheduler(sched)
+{
+    new (&m_tcp_acceptors[0]) acceptor_t(m_default_scheduler.get_executor());
+}
+
+acceptors_base::acceptors_base(size_t) :
+    m_default_scheduler(),
+    m_active_scheduler(m_default_scheduler)
+{
+    new (&m_tcp_acceptors[0]) acceptor_t(m_default_scheduler.get_executor());
+}
+
+acceptors_base::~acceptors_base()
+{
+    m_tcp_acceptors[0].~basic_socket_acceptor();
+}
+#endif
     
 // tcp::server member functions
 
-server::server(scheduler& sched, const unsigned int tcp_port)
-    : m_logger(PION_GET_LOGGER("pion.tcp.server")),
-    m_active_scheduler(sched),
-    m_tcp_acceptor(m_active_scheduler.get_executor()),
+server::server(scheduler& sched, const unsigned int tcp_port) :
+    acceptors_base(sched, 1),
+    m_logger(PION_GET_LOGGER("pion.tcp.server")),
 #ifdef PION_HAVE_SSL
     m_ssl_context(boost::asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
-    m_endpoint(boost::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
-{}
-    
-server::server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint)
-    : m_logger(PION_GET_LOGGER("pion.tcp.server")),
-    m_active_scheduler(sched),
-    m_tcp_acceptor(m_active_scheduler.get_executor()),
-#ifdef PION_HAVE_SSL
-    m_ssl_context(boost::asio::ssl::context::sslv23),
-#else
-    m_ssl_context(0),
-#endif
-    m_endpoint(endpoint), m_ssl_flag(false), m_is_listening(false)
+    m_endpoints(1, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), tcp_port)),
+    m_ssl_flag(false),
+    m_is_listening(false)
 {}
 
-server::server(const unsigned int tcp_port)
-    : m_logger(PION_GET_LOGGER("pion.tcp.server")),
-    m_default_scheduler(), m_active_scheduler(m_default_scheduler),
-    m_tcp_acceptor(m_active_scheduler.get_executor()),
+server::server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint) :
+    acceptors_base(sched, 1),
+    m_logger(PION_GET_LOGGER("pion.tcp.server")),
 #ifdef PION_HAVE_SSL
     m_ssl_context(boost::asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
-    m_endpoint(boost::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
+    m_endpoints(1, endpoint),
+    m_ssl_flag(false),
+    m_is_listening(false)
 {}
 
-server::server(const boost::asio::ip::tcp::endpoint& endpoint)
-    : m_logger(PION_GET_LOGGER("pion.tcp.server")),
-    m_default_scheduler(), m_active_scheduler(m_default_scheduler),
-    m_tcp_acceptor(m_active_scheduler.get_executor()),
+server::server(const unsigned int tcp_port) :
+    acceptors_base(1),
+    m_logger(PION_GET_LOGGER("pion.tcp.server")),
 #ifdef PION_HAVE_SSL
     m_ssl_context(boost::asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
-    m_endpoint(endpoint), m_ssl_flag(false), m_is_listening(false)
+    m_endpoints(1, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), tcp_port)),
+    m_ssl_flag(false),
+    m_is_listening(false)
 {}
+
+server::server(const boost::asio::ip::tcp::endpoint& endpoint) :
+    acceptors_base(1),
+    m_logger(PION_GET_LOGGER("pion.tcp.server")),
+#ifdef PION_HAVE_SSL
+    m_ssl_context(boost::asio::ssl::context::sslv23),
+#else
+    m_ssl_context(0),
+#endif
+    m_endpoints(1, endpoint),
+    m_ssl_flag(false),
+    m_is_listening(false)
+{}
+
+#ifdef BOOST_ASIO_HAS_MOVE
+server::server(endpoints_t endpoints) :
+    acceptors_base{ endpoints.size() },
+    m_logger(PION_GET_LOGGER("pion.tcp.server")),
+#ifdef PION_HAVE_SSL
+    m_ssl_context{ boost::asio::ssl::context::sslv23 },
+#else
+    m_ssl_context(0),
+#endif
+    m_endpoints{ move(endpoints) },
+    m_ssl_flag{ false },
+    m_is_listening{ false }
+{}
+   
+server::server(scheduler& sched, endpoints_t endpoints) :
+    acceptors_base{ sched, endpoints.size() },
+    m_logger(PION_GET_LOGGER("pion.tcp.server")),
+#ifdef PION_HAVE_SSL
+    m_ssl_context{ boost::asio::ssl::context::sslv23 },
+#else
+    m_ssl_context(0),
+#endif
+    m_endpoints{ move(endpoints) },
+    m_ssl_flag{ false },
+    m_is_listening{ false }
+{}
+#endif
     
 void server::start(void)
 {
+    if (m_endpoints.empty())
+        throw std::logic_error{ "List of endpoints can't be empty." };
+
     // lock mutex for thread safety
     boost::mutex::scoped_lock server_lock(m_mutex);
 
     if (! m_is_listening) {
-        PION_LOG_INFO(m_logger, "Starting server on port " << get_port());
-        
         before_starting();
 
         // configure the acceptor service
-        try {
-            // get admin permissions in case we're binding to a privileged port
-            pion::admin_rights use_admin_rights(get_port() > 0 && get_port() < 1024);
-            m_tcp_acceptor.open(m_endpoint.protocol());
-            // allow the acceptor to reuse the address (i.e. SO_REUSEADDR)
-            // ...except when running not on Windows - see http://msdn.microsoft.com/en-us/library/ms740621%28VS.85%29.aspx
+        for (size_t i = 0, n = boost::size(m_tcp_acceptors); i < n; ++i) {
+            PION_LOG_INFO(m_logger, "Starting server on endpoint " << m_endpoints[i]);
+
+            try {
+                // alias
+                acceptor_t& acceptor = m_tcp_acceptors[i];
+                boost::asio::ip::tcp::endpoint& endpoint = m_endpoints[i];
+
+                // get admin permissions in case we're binding to a privileged port
+                pion::admin_rights use_admin_rights(endpoint.port() > 0 && endpoint.port() < 1024);
+                acceptor.open(endpoint.protocol());
+                // allow the acceptor to reuse the address (i.e. SO_REUSEADDR)
+                // ...except when running not on Windows - see http://msdn.microsoft.com/en-us/library/ms740621%28VS.85%29.aspx
 #ifndef PION_WIN32
-            m_tcp_acceptor.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+                acceptor_t::reuse_address(true));
 #endif
-            m_tcp_acceptor.bind(m_endpoint);
-            if (m_endpoint.port() == 0) {
-                // update the endpoint to reflect the port chosen by bind
-                m_endpoint = m_tcp_acceptor.local_endpoint();
-            }
-            m_tcp_acceptor.listen();
+                acceptor.bind(endpoint);
+                if (endpoint.port() == 0) {
+                    // update the endpoint to reflect the port chosen by bind
+                    endpoint = acceptor.local_endpoint();
+                }
+                acceptor.listen();
         } catch (std::exception& e) {
-            PION_LOG_ERROR(m_logger, "Unable to bind to port " << get_port() << ": " << e.what());
+            PION_LOG_ERROR(m_logger, "Unable to bind to endpoint " << m_endpoints[i] << ": " << e.what());
             throw;
+        }
         }
 
         m_is_listening = true;
@@ -116,12 +211,20 @@ void server::stop(bool wait_until_finished)
     boost::mutex::scoped_lock server_lock(m_mutex);
 
     if (m_is_listening) {
-        PION_LOG_INFO(m_logger, "Shutting down server on port " << get_port());
-    
         m_is_listening = false;
 
+        struct acceptor_closer
+        {
+            typedef void result_type;
+            void operator()(pion::logger& m_logger, acceptor_t& acceptor)
+            {
+                PION_LOG_INFO(m_logger, "Shutting down server on endpoint " << acceptor.local_endpoint());
+                acceptor.close();
+            }
+        };
         // this terminates any connections waiting to be accepted
-        m_tcp_acceptor.close();
+        std::for_each(boost::rbegin(m_tcp_acceptors), boost::rend(m_tcp_acceptors),
+            boost::bind(acceptor_closer(), boost::ref(m_logger), _1));
         
         if (! wait_until_finished) {
             // this terminates any other open connections
@@ -176,23 +279,30 @@ void server::listen(void)
     boost::mutex::scoped_lock server_lock(m_mutex);
     
     if (m_is_listening) {
-        // create a new TCP connection object
-        tcp::connection_ptr new_connection(connection::create(get_executor(),
-                                                              m_ssl_context, m_ssl_flag,
-                                                              boost::bind(&server::finish_connection,
-                                                                          this, _1)));
-        
         // prune connections that finished uncleanly
         prune_connections();
 
-        // keep track of the object in the server's connection pool
-        m_conn_pool.insert(new_connection);
-        
-        // use the object to accept a new connection
-        new_connection->async_accept(m_tcp_acceptor,
-                                     boost::bind(&server::handle_accept,
-                                                 this, new_connection,
-                                                 boost::asio::placeholders::error));
+        for (size_t i = 0, n = boost::size(m_tcp_acceptors); i < n; ++i)
+        {
+            // alias
+            acceptor_t& acceptor = m_tcp_acceptors[i];
+
+            // create a new TCP connection object
+            tcp::connection_ptr new_connection(connection::create(get_executor(),
+                m_ssl_context, m_ssl_flag,
+                boost::bind(&server::finish_connection,
+                    this, _1),
+                acceptor.local_endpoint()));
+
+            // keep track of the object in the server's connection pool
+            m_conn_pool.insert(new_connection);
+
+            // use the object to accept a new connection
+            new_connection->async_accept(acceptor,
+                boost::bind(&server::handle_accept,
+                    this, new_connection,
+                    boost::asio::placeholders::error));
+        }
     }
 }
 
@@ -204,13 +314,13 @@ void server::handle_accept(const tcp::connection_ptr& tcp_conn,
         // this happens when the server is being shut down
         if (m_is_listening) {
             listen();   // schedule acceptance of another connection
-            PION_LOG_WARN(m_logger, "Accept error on port " << get_port() << ": " << accept_error.message());
+            PION_LOG_WARN(m_logger, "Accept error on endpoint " << tcp_conn->get_local_endpoint() << ": " << accept_error.message());
         }
         finish_connection(tcp_conn);
     } else {
         // got a new TCP connection
         PION_LOG_DEBUG(m_logger, "New" << (tcp_conn->get_ssl_flag() ? " SSL " : " ")
-                       << "connection on port " << get_port());
+                       << "connection on endpoint " << tcp_conn->get_local_endpoint());
 
         // schedule the acceptance of another new connection
         // (this returns immediately since it schedules it as an event)
@@ -234,12 +344,12 @@ void server::handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
 {
     if (handshake_error) {
         // an error occured while trying to establish the SSL connection
-        PION_LOG_WARN(m_logger, "SSL handshake failed on port " << get_port()
+        PION_LOG_WARN(m_logger, "SSL handshake failed on endpoint " << tcp_conn->get_local_endpoint()
                       << " (" << handshake_error.message() << ')');
         finish_connection(tcp_conn);
     } else {
         // handle the new connection
-        PION_LOG_DEBUG(m_logger, "SSL handshake succeeded on port " << get_port());
+        PION_LOG_DEBUG(m_logger, "SSL handshake succeeded on endpoint " << tcp_conn->get_local_endpoint());
         handle_connection(tcp_conn);
     }
 }
@@ -253,7 +363,7 @@ void server::finish_connection(const tcp::connection_ptr& tcp_conn)
         handle_connection(tcp_conn);
 
     } else {
-        PION_LOG_DEBUG(m_logger, "Closing connection on port " << get_port());
+        PION_LOG_DEBUG(m_logger, "Closing connection on endpoint " << tcp_conn->get_local_endpoint());
         
         // remove the connection from the server's management pool
         ConnectionPool::iterator conn_itr = m_conn_pool.find(tcp_conn);
@@ -272,11 +382,9 @@ std::size_t server::prune_connections(void)
     ConnectionPool::iterator conn_itr = m_conn_pool.begin();
     while (conn_itr != m_conn_pool.end()) {
         if (conn_itr->unique()) {
-            PION_LOG_WARN(m_logger, "Closing orphaned connection on port " << get_port());
-            ConnectionPool::iterator erase_itr = conn_itr;
-            ++conn_itr;
-            (*erase_itr)->close();
-            m_conn_pool.erase(erase_itr);
+            PION_LOG_WARN(m_logger, "Closing orphaned connection on endpoint " << (*conn_itr)->get_local_endpoint());
+            (*conn_itr)->close();
+            conn_itr = m_conn_pool.erase(conn_itr);
         } else {
             ++conn_itr;
         }
@@ -291,6 +399,17 @@ std::size_t server::get_connections(void) const
     boost::mutex::scoped_lock server_lock(m_mutex);
     return (m_is_listening ? (m_conn_pool.size() - 1) : m_conn_pool.size());
 }
+
+#ifdef BOOST_ASIO_HAS_MOVE
+void server::set_endpoints(endpoints_t endpoints)
+{
+    if (m_is_listening)
+        throw std::logic_error{ "Endpoints can't be modified once the tcp server has started." };
+
+    resize_acceptors(endpoints.size());
+    m_endpoints = move(endpoints);
+}
+#endif
 
 }   // end namespace tcp
 }   // end namespace pion


### PR DESCRIPTION
Addresses issue #5:
It can be useful to have a server accepting connections on multiple endpoints (or addresses at the very least).

This PR:
  - requires C++11 to enable multiple listener endpoints (in reverse the one endpoint implementation is kept until C++03)
  - leaves the historic 1-endpoint interface intact
